### PR TITLE
fix(CI): publish actual snapshot images

### DIFF
--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -16,9 +16,60 @@ on:
     - 'release-*'
 
 jobs:
-  container_tests:
+  astarte_appengine_api:
     uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_appengine_api"
     secrets: inherit
+
+  astarte_data_updater_plant:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_data_updater_plant"
+    secrets: inherit
+
+  astarte_housekeeping_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_housekeeping_api"
+    secrets: inherit
+
+  astarte_housekeeping:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_housekeeping"
+    secrets: inherit
+
+  astarte_pairing_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_pairing_api"
+    secrets: inherit
+
+  astarte_pairing:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_pairing"
+    secrets: inherit
+
+  astarte_realm_management_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_realm_management_api"
+    secrets: inherit
+
+  astarte_realm_management:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_realm_management"
+    secrets: inherit
+
+  astarte_trigger_engine:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_trigger_engine"
+    secrets: inherit
+
 
   e2e_tests:
     uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -32,7 +83,15 @@ jobs:
       attestations: write
       id-token: write
     needs:
-    - container_tests
+    - astarte_appengine_api
+    - astarte_data_updater_plant
+    - astarte_housekeeping
+    - astarte_housekeeping_api
+    - astarte_pairing
+    - astarte_pairing_api
+    - astarte_realm_management
+    - astarte_realm_management_api
+    - astarte_trigger_engine
     - e2e_tests
     strategy:
       fail-fast: true


### PR DESCRIPTION
The `astarte-apps-build` workflow was called without the `app` argument when in the context of validation testing before publishing snapshot images of Astarte services. Since the `app` argument is required, this made the whole publishing job fail.
Fix this by passing the right argument to all instances.

copy-paste goes brrrrrrrrrrrrrr